### PR TITLE
Modify TAC meeting agenda template

### DIFF
--- a/.github/ISSUE_TEMPLATE/tac_meeting_agenda.yml
+++ b/.github/ISSUE_TEMPLATE/tac_meeting_agenda.yml
@@ -1,0 +1,39 @@
+name: TAC Meeting agenda item
+description: Propose an agenda item to discuss at an upcoming TAC meeting
+title: "AGENDA TOPIC"
+labels: ["tac-meeting"]
+assignees: 
+  - michellearoth
+  - reginankenchor
+  - Naomi-Wash
+body:
+  - type: markdown
+    attributes:
+      value: |
+        The TAC is always looking for topics of interest to the community. 
+        Please set the issue title above to your proposed agenda topic and fill out
+        the details below to have it added to a future TAC meeting agenda.
+        Please note that you must be available to lead this discussion at a TAC meeting.
+        You can find information about TAC meetings and how to join them in the
+        [TAC README](https://github.com/pytorch-fdn/tac/blob/main/README.md).
+  - type: textarea
+    id: details
+    attributes:
+      label: Please share any additional details on this topic
+    validations:
+      required: true
+  - type: textarea
+    id: tac-action
+    attributes:
+      label: Detail what actions or feedback you would like from the TAC
+    validations:
+      required: true
+  - type: dropdown
+    id: topic-length
+    attributes:
+      label: How much time do you need for this topic?
+      description: Pick the option closest to the time you need for the topic.
+      multiple: false
+      options:
+        - 5 minutes or less
+        - At least 30 minutes


### PR DESCRIPTION
Updated labels and assignees for TAC meeting agenda item template. Revised body text for clarity and added link to TAC README.